### PR TITLE
Update webui-user.sh to call bash through /usr/bin/env

### DIFF
--- a/webui-user.sh
+++ b/webui-user.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #########################################################
 # Uncomment and change the variables below to your need:#
 #########################################################


### PR DESCRIPTION
/bin/bash does not exist on NixOS

## Checklist:

- [X] I have read [contributing wiki page](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing)
- [X] I have performed a self-review of my own code
- [X] My code follows the [style guidelines](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing#code-style)
- [X] My code passes [tests](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Tests)
